### PR TITLE
feat: adicionar registro de usuário com integração de API e ban…

### DIFF
--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/config/AppConfig.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/config/AppConfig.java
@@ -1,0 +1,17 @@
+package com.qmasters.fila_flex.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+     @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}
+    
+    
+

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/controller/UserController.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.qmasters.fila_flex.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,8 +28,17 @@ public class UserController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<User> registerUser(@RequestBody User user) {
-        User savedUser = userService.saveUser(user);
-        return ResponseEntity.ok(savedUser);
+    public ResponseEntity<?> registerUser(@RequestBody User user) {
+        try {
+            User savedUser = userService.saveUser(user);
+            return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 }

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/AuthService.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import com.qmasters.fila_flex.dto.UserDTO;
 import com.qmasters.fila_flex.model.User;
@@ -21,6 +22,11 @@ public class AuthService implements UserDetailsService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Autowired
+    private RestTemplate restTemplate;
+
+    private static final String REGISTER_URL = "http://localhost:8080/users/register";
+
     public User register(UserDTO userDTO) {
         if (userRepository.findByEmail(userDTO.getEmail()).isPresent()) {
             throw new RuntimeException("Email já cadastrado!");
@@ -33,6 +39,10 @@ public class AuthService implements UserDetailsService {
         user.setRole(UserRole.valueOf(userDTO.getRole())); 
         
         return userRepository.save(user);
+    }
+
+    public User registerWithApi(UserDTO userDTO) {
+        return restTemplate.postForObject(REGISTER_URL, userDTO, User.class);
     }
 
     @Override

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/TokenService.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/TokenService.java
@@ -1,11 +1,13 @@
 package com.qmasters.fila_flex.service;
 
 import java.util.Date;
+import java.util.function.Function;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -26,5 +28,33 @@ public class TokenService {
                 .setExpiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(Keys.hmacShaKeyFor(secret.getBytes()),SignatureAlgorithm.HS512)
                 .compact();
+    }
+    public boolean validateToken(String token, UserDetails userDetails) {
+        final String username = extractUsername(token);
+        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+     public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secret.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
     }
 }


### PR DESCRIPTION
…co de dados local

- Implementar método de registro de usuário que salva o usuário no banco de dados local com verificação de unicidade de 
email e criptografia de senha.
- Adicionar método para registrar usuário via API externa usando RestTemplate.
- Garantir implementação de UserDetailsService para autenticação de usuário.