### PR TITLE
feat: adicona botão de logout e impede acesso à rota /login quando já se está logado

### DIFF
--- a/Frontend/FilaFlex/src/app/auth/guards/auth.guard.ts
+++ b/Frontend/FilaFlex/src/app/auth/guards/auth.guard.ts
@@ -12,7 +12,7 @@ export const authGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
     return router.createUrlTree(['/login']);
   }
 
-  if (requiredRole && !authService.hasRole(requiredRole)) {
+  if (requiredRole && !authService.hasRole(requiredRole.toUpperCase())) {
     return router.createUrlTree(['/unauthorized']);
   }
 

--- a/Frontend/FilaFlex/src/app/auth/guards/login.guard.spec.ts
+++ b/Frontend/FilaFlex/src/app/auth/guards/login.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { loginGuard } from './login.guard';
+
+describe('loginGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => loginGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/Frontend/FilaFlex/src/app/auth/guards/login.guard.ts
+++ b/Frontend/FilaFlex/src/app/auth/guards/login.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const loginGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return router.createUrlTree(['/home']); //Redireciona para a página inicial se o usuário já estiver logado
+  }
+
+  return true;
+};


### PR DESCRIPTION
- Adicona botão de logout na página inicial que desloga o usuário e redireciona para a página de login
- Implementa guarda de rota LoginGuard para redirecionar usuários logados para a página inicial ao tentar acessar /login
- Atualiza configuração de rotas para usar LoginGuard na rota /login