### PR TITLE
feat(service-management): integrar gerenciamento de serviços com API

### DIFF
--- a/Frontend/FilaFlex/src/app/app.routes.ts
+++ b/Frontend/FilaFlex/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { AdminComponent } from './admin/admin.component';
 import { UnauthorizedComponent } from './unauthorized/unauthorized.component';
 import { authGuard } from './auth/guards/auth.guard';
 import { loginGuard } from './auth/guards/login.guard';
+import { ServiceManagementComponent } from './service-management/service-management.component';
 
 const routes: Routes = [
   { path: 'register', component: RegisterComponent },
@@ -13,6 +14,7 @@ const routes: Routes = [
   { path: 'home', component: HomeComponent, canActivate: [authGuard] },
   { path: 'admin', component: AdminComponent, canActivate: [authGuard], data: { role: 'ADMIN' } },
   { path: 'unauthorized', component: UnauthorizedComponent },
+  { path: 'filas', component: ServiceManagementComponent, /*canActivate: [authGuard]*/ },
   { path: '', redirectTo: '/login', pathMatch: 'full' },
 ];
 

--- a/Frontend/FilaFlex/src/app/service-management/db.json
+++ b/Frontend/FilaFlex/src/app/service-management/db.json
@@ -1,0 +1,28 @@
+{
+  "services": [
+    {
+      "name": "Novo Serviço",
+      "description": "Descrição do serviço",
+      "category": "Categoria",
+      "price": 100,
+      "executionTime": "1 hora",
+      "deliveryDate": "2025-03-20",
+      "documentation": "Nenhuma",
+      "id": 1
+    }
+  ],
+  "filas": [
+    {
+      "id": 1,
+      "name": "Fila de Atendimento Médico",
+      "type": "Saúde",
+      "priority": "Alta"
+    },
+    {
+      "id": 2,
+      "name": "Fila de Atendimento Bancário",
+      "type": "Financeiro",
+      "priority": "Média"
+    }
+  ]
+}

--- a/Frontend/FilaFlex/src/app/service-management/service-management.component.ts
+++ b/Frontend/FilaFlex/src/app/service-management/service-management.component.ts
@@ -1,16 +1,24 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { ServiceTableComponent } from '../service-table/service-table.component';
+import { HttpClientModule } from '@angular/common/http';
 
 @Component({
   selector: 'app-service-management',
+  standalone: true,
+  imports: [ServiceTableComponent, HttpClientModule],
   template: `
     <div class="p-6">
       <div class="flex justify-between items-center mb-4">
-        <h1 class="text-2xl font-bold">Gerenciamento de Filas de Atendimento</h1>
-        <button (click)="handleAddQueue()" class="btn btn-primary">Adicionar Fila</button>
+        <h1 class="text-2xl font-bold">Gerenciamento de Serviços</h1>
+        <button (click)="handleAddService()" class="btn btn-primary">Adicionar Serviço</button>
       </div>
       
-      <app-queue-table [queues]="queues" (editQueue)="handleEditQueue($event)" (deleteQueue)="handleDeleteQueue($event)"></app-queue-table>
+      <app-service-table 
+        [services]="services" 
+        (editService)="handleEditService($event)" 
+        (deleteService)="handleDeleteService($event)">
+      </app-service-table>
     </div>
   `,
   styles: [
@@ -27,43 +35,65 @@ import { HttpClient } from '@angular/common/http';
     `
   ]
 })
-export class ServiceManagementComponent implements OnInit {
-  queues: any[] = [];
-  private apiUrl = 'http://localhost:3000/queues'; // URL da API para testes no Insomnia
+export class ServiceManagementComponent {
+  services: any[] = [];
+
+  private apiUrl = 'http://localhost:3000/services';
 
   constructor(private http: HttpClient) {}
 
   ngOnInit(): void {
-    this.loadQueues();
+    this.loadServices();
   }
 
-  loadQueues(): void {
+  loadServices(): void {
     this.http.get<any[]>(this.apiUrl).subscribe(
-      (data) => this.queues = data,
-      (error) => console.error('Erro ao carregar filas:', error)
+      (data) => this.services = data,
+      (error) => console.error('Erro ao carregar serviços:', error)
     );
   }
 
-  handleAddQueue(): void {
-    const newQueue = { name: 'Nova Fila', type: 'Outro', priority: 'Média' };
-    this.http.post<any>(this.apiUrl, newQueue).subscribe(
-      (data) => this.queues = [...this.queues, data],
-      (error) => console.error('Erro ao adicionar fila:', error)
+  // Método para adicionar serviço
+  handleAddService(): void {
+    const newService = {
+      name: 'Novo Serviço',
+      description: 'Descrição do serviço',
+      category: 'Categoria',
+      price: 100,
+      executionTime: '1 hora',
+      deliveryDate: '2025-03-20',
+      documentation: 'Nenhuma'
+    };
+
+    this.http.post<any>(this.apiUrl, newService).subscribe(
+      (data) => this.services = [...this.services, data],
+      (error) => console.error('Erro ao adicionar serviço:', error)
     );
   }
 
-  handleEditQueue(id: number): void {
-    const updatedQueue = { name: 'Fila Atualizada', type: 'Outro', priority: 'Alta' };
-    this.http.put<any>(`${this.apiUrl}/${id}`, updatedQueue).subscribe(
-      () => this.loadQueues(),
-      (error) => console.error('Erro ao editar fila:', error)
+  // Método para editar serviço
+  handleEditService(id: number): void {
+    const updatedService = {
+      name: 'Serviço Atualizado',
+      description: 'Nova descrição',
+      category: 'Nova Categoria',
+      price: 200,
+      executionTime: '2 horas',
+      deliveryDate: '2025-03-22',
+      documentation: 'Documento atualizado'
+    };
+
+    this.http.put<any>(`${this.apiUrl}/${id}`, updatedService).subscribe(
+      () => this.loadServices(),
+      (error) => console.error('Erro ao editar serviço:', error)
     );
   }
 
-  handleDeleteQueue(id: number): void {
+  // Método para excluir serviço
+  handleDeleteService(id: number): void {
     this.http.delete(`${this.apiUrl}/${id}`).subscribe(
-      () => this.queues = this.queues.filter(queue => queue.id !== id),
-      (error) => console.error('Erro ao excluir fila:', error)
+      () => this.services = this.services.filter(service => service.id !== id),
+      (error) => console.error('Erro ao excluir serviço:', error)
     );
   }
 }

--- a/Frontend/FilaFlex/src/app/service-table/service-table.component.spec.ts
+++ b/Frontend/FilaFlex/src/app/service-table/service-table.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ServiceTableComponent } from './service-table.component';
+
+describe('ServiceTableComponent', () => {
+  let component: ServiceTableComponent;
+  let fixture: ComponentFixture<ServiceTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ServiceTableComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ServiceTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/FilaFlex/src/app/service-table/service-table.component.ts
+++ b/Frontend/FilaFlex/src/app/service-table/service-table.component.ts
@@ -1,0 +1,71 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-service-table',
+  standalone: true,
+  imports: [CommonModule], // ✅ Necessário para usar *ngFor
+  template: `
+    <table class="table-auto w-full border-collapse border border-gray-300">
+      <thead>
+        <tr class="bg-gray-100">
+          <th class="border p-2">ID</th>
+          <th class="border p-2">Nome</th>
+          <th class="border p-2">Descrição</th>
+          <th class="border p-2">Categoria</th>
+          <th class="border p-2">Preço</th>
+          <th class="border p-2">Tempo de Execução</th>
+          <th class="border p-2">Data de Entrega</th>
+          <th class="border p-2">Documentação</th>
+          <th class="border p-2">Ações</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let service of services" class="border">
+          <td class="border p-2">{{ service.id }}</td>
+          <td class="border p-2">{{ service.name }}</td>
+          <td class="border p-2">{{ service.description }}</td>
+          <td class="border p-2">{{ service.category }}</td>
+          <td class="border p-2">{{ service.price | currency }}</td>
+          <td class="border p-2">{{ service.executionTime }}</td>
+          <td class="border p-2">{{ service.deliveryDate }}</td>
+          <td class="border p-2">{{ service.documentation }}</td>
+          <td class="border p-2 flex gap-2">
+            <button (click)="editService.emit(service.id)" class="btn btn-outline">Editar</button>
+            <button (click)="deleteService.emit(service.id)" class="btn btn-danger">Excluir</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `,
+  styles: [
+    `
+      .btn {
+        padding: 6px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      .btn-outline {
+        border: 1px solid #007bff;
+        color: #007bff;
+        margin-right: 5px;
+      }
+      .btn-outline:hover {
+        background-color: #007bff;
+        color: white;
+      }
+      .btn-danger {
+        background-color: #dc3545;
+        color: white;
+      }
+      .btn-danger:hover {
+        background-color: #c82333;
+      }
+    `
+  ]
+})
+export class ServiceTableComponent {
+  @Input() services: any[] = [];
+  @Output() editService = new EventEmitter<number>();
+  @Output() deleteService = new EventEmitter<number>();
+}


### PR DESCRIPTION
- Implementado o ServiceManagementComponent para listar, adicionar e remover serviços.
- Criado o ServiceTableComponent para exibição dos serviços em uma tabela.
- Configurada a requisição para http://localhost:3000/services utilizando HttpClient.
- Testes realizados acessando http://localhost:4200/filas e verificando a exibição correta dos serviços.

Obs: queue-table foi removido para melhor adequação de história de usuário. Por enquanto, a funcionalidade de edição dinâmica ao clicar o botão 'Editar' em localhost:4200/filas não está funcionando completamente, contudo já é possível adicionar e excluir. O trecho de Path no arquivo app.routes.ts está com o 'canActivate:' comentado pois acessei diretamente pela url do navegador afim de testes mas esta funcionalidade só deve estar disponível para administradores.