### PR TITLE
Implementação da exclusão de AppointmentTypes

### DIFF
--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/controller/AppointmentTypeController.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/controller/AppointmentTypeController.java
@@ -55,6 +55,11 @@ public class AppointmentTypeController {
         return service.findByPriceBetween(minPrice, maxPrice);
     }
 
+    @DeleteMapping("/delete/{name}")
+    public void deleteByName(@PathVariable String name) {
+        service.deleteByName(name);
+    }    
+
     @GetMapping("/{id}")
     public AppointmentTypeDTO findById(@PathVariable Long id) {
         return service.findById(id);

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/repository/AppointmentTypeRepository.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/repository/AppointmentTypeRepository.java
@@ -2,6 +2,7 @@ package com.qmasters.fila_flex.repository;
 
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,7 @@ public interface AppointmentTypeRepository extends JpaRepository<AppointmentType
     //Busca AppointmentTypes que tenham o preço entre os valores especificados.
     @Query("SELECT a FROM AppointmentType a WHERE a.price BETWEEN :minPrice AND :maxPrice")
     List<AppointmentType> findByPriceBetween(@Param("minPrice") Double minPrice, @Param("maxPrice") Double maxPrice);
+
+    //Busca por nome.
+    Optional<AppointmentType> findByName(String name);
 }

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/AppointmentTypeService.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/AppointmentTypeService.java
@@ -71,6 +71,16 @@ public class AppointmentTypeService {
         repository.deleteById(id);
     }
 
+    //Método para deletar AppointmentType por nome.
+    public void deleteByName(String name) {
+        // Encontra o AppointmentType pelo nome
+        AppointmentType appointmentType = repository.findByName(name)
+            .orElseThrow(() -> new RuntimeException("Tipo de agendamento não encontrado com o nome: " + name));
+        
+        // Deleta o AppointmentType
+        repository.delete(appointmentType);
+    }
+
     private AppointmentTypeDTO toDTO(AppointmentType appointmentType) {
         return new AppointmentTypeDTO(appointmentType.getName(),
                 appointmentType.getDescription(),

--- a/Frontend/FilaFlex/src/app/service-management/service-management.component.ts
+++ b/Frontend/FilaFlex/src/app/service-management/service-management.component.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AppointmentType, AppointmentTypeService } from '../services/appointment-type.service';
+import { catchError, Observable } from 'rxjs';
 
 @Component({
   selector: 'app-service-management',
@@ -48,15 +49,15 @@ export class ServiceManagementComponent implements OnInit {
   }
   
   loadAppointmentTypes(): void {
-    this.appointmentTypeService.getAppointmentTypes().subscribe(
-      data => {
+    this.appointmentTypeService.getAppointmentTypes().subscribe({
+      next: (data) => {
         this.appointmentTypes = data;
         console.log('Appointment types carregados:', data);
       },
-      error => {
+      error: (error) => {
         console.error('Erro ao carregar os tipos de serviço:', error);
       }
-    );
+    });
   }
   
   toggleForm(): void {
@@ -70,14 +71,14 @@ export class ServiceManagementComponent implements OnInit {
     if (this.appointmentTypeForm.invalid) {
       return;
     }
-
+  
     const formData = this.prepareFormData();
     console.log('Dados preparados para envio:', formData);
-
+  
     if (this.isEditing && this.currentAppointmentType) {
       // Atualizar serviço existente
-      this.appointmentTypeService.updateAppointmentType(formData).subscribe(
-        updated => {
+      this.appointmentTypeService.updateAppointmentType(formData).subscribe({
+        next: (updated) => {
           console.log('Serviço atualizado com sucesso:', updated);
           const index = this.appointmentTypes.findIndex(a => a.name === this.currentAppointmentType?.name);
           if (index !== -1) {
@@ -85,22 +86,22 @@ export class ServiceManagementComponent implements OnInit {
           }
           this.resetForm();
         },
-        error => {
+        error: (error) => {
           console.error('Erro ao atualizar o serviço:', error);
         }
-      );
+      });
     } else {
       // Adicionar novo serviço
-      this.appointmentTypeService.createAppointmentType(formData).subscribe(
-        created => {
+      this.appointmentTypeService.createAppointmentType(formData).subscribe({
+        next: (created) => {
           console.log('Serviço criado com sucesso:', created);
           this.appointmentTypes.push(created);
           this.resetForm();
         },
-        error => {
+        error: (error) => {
           console.error('Erro ao criar o serviço:', error);
         }
-      );
+      });
     }
   }
 
@@ -155,19 +156,23 @@ export class ServiceManagementComponent implements OnInit {
     });
   }
 
+
   deleteAppointmentType(appointmentType: AppointmentType): void {
-    if (confirm(`Tem certeza que deseja excluir o serviço "${appointmentType.name}"?`)) {
-      // Agora passa o appointmentType completo, não apenas o ID
-      this.appointmentTypeService.deleteAppointmentType(appointmentType).subscribe(
-        () => {
+    if (!appointmentType.name) {
+      console.error('Não é possível excluir: nome não encontrado');
+      return;
+    }
+    
+    this.appointmentTypeService.deleteAppointmentTypeByName(appointmentType.name)
+      .subscribe({
+        next: () => {
           console.log('Serviço excluído com sucesso');
           this.appointmentTypes = this.appointmentTypes.filter(a => a.name !== appointmentType.name);
         },
-        error => {
+        error: (error) => {
           console.error('Erro ao excluir o serviço:', error);
         }
-      );
-    }
+      });
   }
 
   cancelForm(): void {


### PR DESCRIPTION
# Implementação da exclusão de serviços por nome

## Descrição
Adicionada funcionalidade para excluir tipos de agendamento (AppointmentType) pelo nome.

## Alterações
- **Backend**:
  - Criado endpoint `DELETE /appointment-types/delete/{name}`
  - Implementados métodos `findByName` e `deleteByName` no `AppointmentTypeService`
- **Frontend**:
  - Adicionado suporte para enviar requisições de exclusão usando o nome do serviço
  - Atualização automática da interface após exclusão bem-sucedida