### PR TITLE
feat: Adicionar proteção de rota para Admin em /ServiceManagement

### DIFF
--- a/Frontend/FilaFlex/src/app/app.config.ts
+++ b/Frontend/FilaFlex/src/app/app.config.ts
@@ -1,17 +1,10 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { Routes, provideRouter } from '@angular/router';
-import { authGuard, adminGuard } from './auth/guards/auth.guard';
+import { provideRouter } from '@angular/router';
 import routes from './app.routes';
-
-const appRoutes: Routes = [
-  { path: '', loadComponent: () => import('./home/home.component').then(m => m.HomeComponent) },
-  { path: 'login', loadComponent: () => import('./auth/login/login.component').then(m => m.LoginComponent) },
-  { path: 'ServiceManagement', loadComponent: () => import('./service-management/service-management.component').then(m => m.ServiceManagementComponent), canActivate: [adminGuard] }
-];
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(appRoutes)
+    provideRouter(routes)
   ]
 };

--- a/Frontend/FilaFlex/src/app/app.config.ts
+++ b/Frontend/FilaFlex/src/app/app.config.ts
@@ -1,8 +1,17 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { Routes, provideRouter } from '@angular/router';
+import { authGuard, adminGuard } from './auth/guards/auth.guard';
+import routes from './app.routes';
 
-import { routes } from './app.routes';
+const appRoutes: Routes = [
+  { path: '', loadComponent: () => import('./home/home.component').then(m => m.HomeComponent) },
+  { path: 'login', loadComponent: () => import('./auth/login/login.component').then(m => m.LoginComponent) },
+  { path: 'ServiceManagement', loadComponent: () => import('./service-management/service-management.component').then(m => m.ServiceManagementComponent), canActivate: [adminGuard] }
+];
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes)
+  ]
 };

--- a/Frontend/FilaFlex/src/app/auth/guards/admin.guard.ts
+++ b/Frontend/FilaFlex/src/app/auth/guards/admin.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service'; // Ajuste o caminho conforme necessário
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AdminGuard implements CanActivate {
+
+  constructor(private authService: AuthService, private router: Router) {}
+
+  canActivate(): boolean {
+    const user = this.authService.getCurrentUser();
+    
+    if (user && user.role === 'ADMIN') {
+      return true;
+    } else {
+      this.router.navigate(['/unauthorized']); // Redireciona para uma página de acesso negado
+      return false;
+    }
+  }
+}

--- a/Frontend/FilaFlex/src/app/auth/guards/auth.guard.ts
+++ b/Frontend/FilaFlex/src/app/auth/guards/auth.guard.ts
@@ -1,19 +1,28 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router, ActivatedRouteSnapshot } from '@angular/router';
+import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
-export const authGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
+export const authGuard: CanActivateFn = (route, state) => {
   const authService = inject(AuthService);
   const router = inject(Router);
 
-  const requiredRole: string | undefined = route.data?.['role'];
-
   if (!authService.isAuthenticated()) {
-    return router.createUrlTree(['/login']);
+    alert('Acesso negado! Você precisa estar autenticado para acessar esta página.');
+    router.navigate(['/']);
+    return false;
   }
 
-  if (requiredRole && !authService.hasRole(requiredRole.toUpperCase())) {
-    return router.createUrlTree(['/unauthorized']);
+  return true;
+};
+
+export const adminGuard: CanActivateFn = (route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.hasRole('admin')) {
+    alert('Acesso negado! Você precisa ser um administrador para acessar esta página.');
+    router.navigate(['/']);
+    return false;
   }
 
   return true;

--- a/Frontend/FilaFlex/src/app/auth/services/auth.service.ts
+++ b/Frontend/FilaFlex/src/app/auth/services/auth.service.ts
@@ -56,16 +56,17 @@ export class AuthService {
   hasRole(requiredRole: string): boolean {
     const token = this.getToken();
     if (!token) {
-      return false;
+        return false;
     }
     try {
-      const decodedToken: any = jwtDecode(token);
-      return decodedToken.role === requiredRole;
+        const decodedToken: any = jwtDecode(token);
+        return decodedToken.role?.toLowerCase() === requiredRole.toLowerCase();
     } catch (error) {
-      console.error('Token error:', error);
-      return false;
+        console.error('Token error:', error);
+        return false;
     }
   }
+
 
   getToken(): string | null {
     return localStorage.getItem('token');
@@ -102,6 +103,29 @@ export class AuthService {
     } catch (error) {
       console.error('Erro ao decodificar token:', error);
       return null;
+    }
+  }
+
+  getCurrentUser(): { id: string; email: string; role: string } | null {
+    const token = this.getToken();
+
+    if (!token) {
+        console.error('Nenhum token encontrado.');
+        return null;
+    }
+
+    try {
+        const decodedToken: any = jwtDecode(token);
+        console.log('Token decodificado:', decodedToken);
+
+        return {
+            id: decodedToken.id || decodedToken.userId || decodedToken.sub || '', // Retorna string vazia se não encontrar um ID válido
+            email: decodedToken.email || 'desconhecido',
+            role: decodedToken.role || 'USER' // Default para 'USER' caso não tenha um role definido
+        };
+    } catch (error) {
+        console.error('Erro ao decodificar token:', error);
+        return null;
     }
   }
 }


### PR DESCRIPTION
- Implementação do authGuard e adminGuard para proteger rotas
- Adição de alertas para feedback do usuário durante os testes (Alerts apenas para deixar explícito)
- Redirecionamento para home caso o usuário não tenha permissão