### PR TITLE
feat: adicionar gerenciamento completo de horários ao agendamento

### DIFF
--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/controller/ReportController.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/controller/ReportController.java
@@ -1,0 +1,32 @@
+package com.qmasters.fila_flex.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import com.qmasters.fila_flex.service.ReportService;
+import com.qmasters.fila_flex.model.Appointment;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reports")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Autowired
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @GetMapping("/appointments")
+    public List<Appointment> getAppointmentsByPeriod(
+            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+        return reportService.getAppointmentsByPeriod(startDate, endDate);
+    }
+}

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/model/Appointment.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/model/Appointment.java
@@ -80,7 +80,7 @@ public class Appointment {
         return appointmentType.getDescription();
     }
 
-    public List<String>getAppointmentTypeCategory() {
+    public List<String> getAppointmentTypeCategory() {
         return appointmentType.getCategory();
     }
 
@@ -152,7 +152,7 @@ public class Appointment {
     public Integer getQueueOrder() {
         return queueOrder;
     }
-    
+
     public void setQueueOrder(Integer queueOrder) {
         this.queueOrder = queueOrder;
     }
@@ -163,5 +163,43 @@ public class Appointment {
 
     public void setPriorityCondition(PriorityCondition priorityCondition) {
         this.priorityCondition = priorityCondition;
+    }
+
+    // Adicione a variável startTime para armazenar o horário de início do atendimento
+    private LocalDateTime startTime;
+
+    // Getter para o startTime
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    // Setter para o startTime
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    // Adicionando os métodos para checkInTime e endTime
+
+    private LocalDateTime checkInTime;
+    private LocalDateTime endTime;
+
+    // Getter para o checkInTime
+    public LocalDateTime getCheckInTime() {
+        return checkInTime;
+    }
+
+    // Setter para o checkInTime
+    public void setCheckInTime(LocalDateTime checkInTime) {
+        this.checkInTime = checkInTime;
+    }
+
+    // Getter para o endTime
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    // Setter para o endTime
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
     }
 }

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/model/AppointmentMetrics.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/model/AppointmentMetrics.java
@@ -1,7 +1,6 @@
 package com.qmasters.fila_flex.model;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/model/AppointmentMetrics.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/model/AppointmentMetrics.java
@@ -1,0 +1,64 @@
+package com.qmasters.fila_flex.model;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AppointmentMetrics {
+
+    // Lista para armazenar os agendamentos
+    private List<Appointment> appointments;
+
+    public AppointmentMetrics() {
+        this.appointments = new ArrayList<>();
+    }
+
+    // Método para adicionar um agendamento à lista
+    public void addAppointment(Appointment appointment) {
+        appointments.add(appointment);
+    }
+
+    // Método para calcular o tempo médio de espera da fila
+    public double calculateAverageWaitTime() {
+        long totalWaitTime = 0;
+        int count = 0;
+
+        for (Appointment appointment : appointments) {
+            if (appointment.getScheduledDateTime() != null && appointment.getStartTime() != null) {
+                totalWaitTime += Duration.between(appointment.getScheduledDateTime(), appointment.getStartTime()).toMinutes();
+                count++;
+            }
+        }
+
+        return count > 0 ? (double) totalWaitTime / count : 0;
+    }
+
+    // Método para calcular o tempo médio de atendimento
+    public double calculateAverageServiceTime() {
+        long totalServiceTime = 0;
+        int count = 0;
+
+        for (Appointment appointment : appointments) {
+            if (appointment.getStartTime() != null && appointment.getCreatedDateTime() != null) {
+                totalServiceTime += Duration.between(appointment.getStartTime(), appointment.getCreatedDateTime()).toMinutes();
+                count++;
+            }
+        }
+
+        return count > 0 ? (double) totalServiceTime / count : 0;
+    }
+
+    // Método para contar o número de atendimentos realizados
+    public int countCompletedAppointments() {
+        int count = 0;
+
+        for (Appointment appointment : appointments) {
+            if (appointment.getStartTime() != null && appointment.getCreatedDateTime() != null) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/AppointmentStatisticsService.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/AppointmentStatisticsService.java
@@ -1,0 +1,45 @@
+package com.qmasters.fila_flex.service;
+
+import java.time.Duration;
+import java.util.List;
+import com.qmasters.fila_flex.repository.AppointmentRepository;
+import com.qmasters.fila_flex.model.Appointment;
+
+public class AppointmentStatisticsService {
+    private final AppointmentRepository appointmentRepository;
+
+    public AppointmentStatisticsService(AppointmentRepository appointmentRepository) {
+        this.appointmentRepository = appointmentRepository;
+    }
+
+    // Retorna o tempo médio de espera antes do atendimento
+    public double getAverageWaitTime() {
+        List<Appointment> appointments = appointmentRepository.findAll();
+        if (appointments.isEmpty()) return 0;
+
+        long totalWaitTime = appointments.stream()
+            .filter(a -> a.getCheckInTime() != null && a.getStartTime() != null)
+            .mapToLong(a -> Duration.between(a.getCheckInTime(), a.getStartTime()).toMinutes())
+            .sum();
+
+        return (double) totalWaitTime / appointments.size();
+    }
+
+    // Retorna o tempo médio de atendimento
+    public double getAverageServiceTime() {
+        List<Appointment> appointments = appointmentRepository.findAll();
+        if (appointments.isEmpty()) return 0;
+
+        long totalServiceTime = appointments.stream()
+            .filter(a -> a.getStartTime() != null && a.getEndTime() != null)
+            .mapToLong(a -> Duration.between(a.getStartTime(), a.getEndTime()).toMinutes())
+            .sum();
+
+        return (double) totalServiceTime / appointments.size();
+    }
+
+    // Retorna a quantidade total de atendimentos realizados
+    public long getTotalAppointments() {
+        return appointmentRepository.count();
+    }
+}

--- a/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/ReportService.java
+++ b/Backend/fila-flex/src/main/java/com/qmasters/fila_flex/service/ReportService.java
@@ -1,0 +1,25 @@
+package com.qmasters.fila_flex.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import com.qmasters.fila_flex.repository.AppointmentRepository;
+import com.qmasters.fila_flex.model.Appointment;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportService {
+
+    private final AppointmentRepository appointmentRepository;
+
+    @Autowired
+    public ReportService(AppointmentRepository appointmentRepository) {
+        this.appointmentRepository = appointmentRepository;
+    }
+
+    // Função que retorna os agendamentos dentro do período fornecido
+    public List<Appointment> getAppointmentsByPeriod(LocalDateTime startDate, LocalDateTime endDate) {
+        return appointmentRepository.findByScheduledDateTime(startDate, endDate);
+    }
+}


### PR DESCRIPTION
- Adicionados os campos 'checkInTime' e 'endTime' à classe Appointment para armazenar os horários de check-in e término do atendimento.
- Implementados os métodos getters e setters para 'checkInTime' e 'endTime', permitindo a captura e atualização desses horários.
- Corrigido o erro de métodos ausentes (getCheckInTime() e getEndTime()) que causava falhas ao acessar esses valores.
- Ajustada a lógica para garantir que os horários de check-in e término sejam gerenciados corretamente durante o ciclo de vida de um agendamento.